### PR TITLE
JS: allow controlling margin size

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bbqr",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bbqr",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "devDependencies": {
         "@scure/base": "^1.2.4",
         "@types/pako": "^2.0.3",

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bbqr",
   "private": false,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/coinkite/BBQr.git",

--- a/js/src/consts.ts
+++ b/js/src/consts.ts
@@ -4,6 +4,8 @@
  * Constants and fixed values.
  */
 
+import { Version } from './types';
+
 // Fixed-length header
 export const HEADER_LEN = 8;
 
@@ -275,6 +277,51 @@ export const QR_DATA_CAPACITY = {
     Q: { 0: 13328, 1: 3993, 2: 2420, 4: 1663, 8: 1024 },
     H: { 0: 10208, 1: 3057, 2: 1852, 4: 1273, 8: 784 },
   },
+} as const;
+
+// map version to size in modules
+// https://github.com/mnooner256/pyqrcode/blob/674a77b5eaf850d063f518bd90c243ee34ad6b5d/pyqrcode/tables.py#L71
+export const QR_SIZE: Record<Version, number> = {
+  1: 21,
+  2: 25,
+  3: 29,
+  4: 33,
+  5: 37,
+  6: 41,
+  7: 45,
+  8: 49,
+  9: 53,
+  10: 57,
+  11: 61,
+  12: 65,
+  13: 69,
+  14: 73,
+  15: 77,
+  16: 81,
+  17: 85,
+  18: 89,
+  19: 93,
+  20: 97,
+  21: 101,
+  22: 105,
+  23: 109,
+  24: 113,
+  25: 117,
+  26: 121,
+  27: 125,
+  28: 129,
+  29: 133,
+  30: 137,
+  31: 141,
+  32: 145,
+  33: 149,
+  34: 153,
+  35: 157,
+  36: 161,
+  37: 165,
+  38: 169,
+  39: 173,
+  40: 177,
 } as const;
 
 // EOF

--- a/js/src/image.ts
+++ b/js/src/image.ts
@@ -6,6 +6,7 @@
 
 import QRCode from 'qrcode';
 import UPNG from 'upng-js';
+import { QR_SIZE } from './consts';
 import { ImageOptions, Version } from './types';
 import { shuffled } from './utils';
 
@@ -28,7 +29,23 @@ export async function renderQRImage(
 
   const mode = options.mode ?? 'animated';
 
-  const margin = 4;
+  let margin = 4;
+
+  if (typeof options.margin === 'number' && options.margin >= 0) {
+    margin = options.margin;
+  } else if (typeof options.margin === 'string' && /^\d+(\.\d+)?%$/.test(options.margin)) {
+    // string like '10%' or '5.5%'
+    const percent = Number(options.margin.slice(0, -1));
+    margin = (QR_SIZE[version] * percent) / 100;
+  } else if (options.margin !== undefined) {
+    throw new Error(
+      'Invalid margin value. Expected a non-negative number or percentage string like "10%". Got: ' +
+        options.margin
+    );
+  }
+
+  margin = Math.round(margin);
+
   const scale = options.scale ?? 4;
 
   if (scale < 1) {

--- a/js/src/types.ts
+++ b/js/src/types.ts
@@ -78,6 +78,13 @@ export type ImageOptions = {
    * @default 4
    */
   scale?: number;
+  /**
+   * The margin or "quiet zone" around the QR code.
+   * Numeric values are interpreted as number of modules.
+   * Percentage values like `10%` are interpreted as a percentage of the QR code size.
+   * @default 4
+   */
+  margin?: number | `${number}%`;
 };
 
 // EOF


### PR DESCRIPTION
Allows specifying the margin or quiet zone size around the QR code when calling `renderQRImage`.